### PR TITLE
feat: rework EIP-1559 fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ const networkGasPrice = await getNetworkGasPrice("ethereum");
 // NOTE: All prices are returned in Gwei units
 ```
 
-> 💡 The price level ("low", "average", "high", "asap") you should use depends on your type of application. Most use cases will do okay with "average" or "high". If your application has background transactions support and execution is not time critical, you could use "low". If your application has a strong need to execute transactions as soon as possible, we recommend using the
-> "asap" option that adds 20% on top of the "high" reported gas price.
+> 💡 The price level ("low", "average", "high", "asap") you should use depends on your type of application. Most use cases will do okay with "average" or "high". If your application has background transactions support and execution is not time critical, you could use "low". If your application has a strong need to execute transactions as soon as possible, we recommend using our custom "asap" option that protects against high gas prices spikes and makes the transaction attractive for miners.
 
 > 🌐 The package currently supports the Ethereum (`"ethereum"`), Polygon (`"polygon"`), Goerli (`"goerli"`), Sepolia (`"sepolia"`), Rinkeby (`"rinkeby"`), and Mumbai (`"mumbai"`) networks. If you would like to add support for a new network, please open an issue or pull request.
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 ![Tests](https://github.com/enzoferey/network-gas-price/actions/workflows/test.yml/badge.svg)
 [![npm version](https://badge.fury.io/js/@enzoferey%2Fnetwork-gas-price.svg)](https://badge.fury.io/js/@enzoferey%2Fnetwork-gas-price)
 [![codecov](https://codecov.io/gh/enzoferey/network-gas-price/branch/main/graph/badge.svg?token=EJR8EAA1U8)](https://codecov.io/gh/enzoferey/network-gas-price)
+![npm bundle size](https://img.shields.io/bundlephobia/minzip/@enzoferey/network-gas-price?color=g&label=gzip%20size)
 
 Query accurate gas prices on every blockchain network ⛽️
 
 ## Highlights
 
 - Zero dependencies 🧹
-- Lightweight (749 bytes gzipped) 📦
+- Lightweight 📦
 - Simple to use ⚡️
 - Ethereum and Polygon networks 🚀
 

--- a/lib/__tests__/getAsapGasPriceLevel.test.ts
+++ b/lib/__tests__/getAsapGasPriceLevel.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { getAsapGasPriceLevel } from "../getAsapGasPriceLevel";
+
+describe("getAsapGasPriceLevel", () => {
+  it("should return the asap gas price level", () => {
+    const result = getAsapGasPriceLevel(100, 20);
+
+    expect(result).toEqual({
+      maxPriorityFeePerGas: 32.5,
+      maxFeePerGas: 232.5,
+    });
+  });
+});

--- a/lib/getAsapGasPriceLevel.ts
+++ b/lib/getAsapGasPriceLevel.ts
@@ -1,0 +1,25 @@
+// Inspired from https://www.blocknative.com/blog/eip-1559-fees
+
+import type { GasPriceLevel } from "./types";
+
+// +12.5% is the maximum increase of base fee per block
+// This means setting a premium max priority fee bigger by 12.5% of base fee
+// means likelyhood of getting into block 2 in a gas spike event is super high
+const PREMIUM_BASE_FEE_PERCENTAGE_FOR_MAX_PRIORITY_FEE = 0.125;
+
+export function getAsapGasPriceLevel(
+  baseFee: number,
+  fastMaxPriorityFee: number
+): GasPriceLevel {
+  const maxPriorityFeePerGas =
+    fastMaxPriorityFee +
+    baseFee * PREMIUM_BASE_FEE_PERCENTAGE_FOR_MAX_PRIORITY_FEE;
+
+  // Using baseFee * 2 ensures the transaction will remain marketable for six consecutive 100% full blocks
+  const maxFeePerGas = baseFee * 2 + maxPriorityFeePerGas;
+
+  return {
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+  };
+}

--- a/lib/networks/__tests__/getEthereumGasPrice.test.ts
+++ b/lib/networks/__tests__/getEthereumGasPrice.test.ts
@@ -5,21 +5,21 @@ import { mockFetch } from "./mockFetch";
 import {
   GAS_STATION_URL_BY_NETWORK,
   DEFAULT_FALLBACK_GAS_PRICE,
-  ASAP_PERCENTAGE,
   getEthereumGasPrice,
 } from "../getEthereumGasPrice";
 
+import { getAsapGasPriceLevel } from "../../getAsapGasPriceLevel";
+
 describe("getEthereumGasPrice", () => {
   it("should return the Ethereum gas prices per level based on the Ethereum gas station", async () => {
-    const lowGasPrice = 100;
-    const averageGasPrice = 110;
-    const fastGasPrice = 120;
+    const suggestBaseFee = 100;
 
     const mock = mockFetch({
       result: {
-        SafeGasPrice: lowGasPrice,
-        ProposeGasPrice: averageGasPrice,
-        FastGasPrice: fastGasPrice,
+        suggestBaseFee: String(suggestBaseFee),
+        SafeGasPrice: "100",
+        ProposeGasPrice: "110",
+        FastGasPrice: "120",
       },
     });
 
@@ -30,33 +30,29 @@ describe("getEthereumGasPrice", () => {
 
     expect(result).toEqual({
       low: {
-        maxPriorityFeePerGas: lowGasPrice,
-        maxFeePerGas: lowGasPrice,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
       },
       average: {
-        maxPriorityFeePerGas: averageGasPrice,
-        maxFeePerGas: averageGasPrice,
+        maxPriorityFeePerGas: 10,
+        maxFeePerGas: 110,
       },
       high: {
-        maxPriorityFeePerGas: fastGasPrice,
-        maxFeePerGas: fastGasPrice,
+        maxPriorityFeePerGas: 20,
+        maxFeePerGas: 120,
       },
-      asap: {
-        maxPriorityFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-        maxFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-      },
+      asap: getAsapGasPriceLevel(suggestBaseFee, 20),
     });
   });
   it("should return the Goerli gas prices per level based on the Ethereum gas station", async () => {
-    const lowGasPrice = 100;
-    const averageGasPrice = 110;
-    const fastGasPrice = 120;
+    const suggestBaseFee = 100;
 
     const mock = mockFetch({
       result: {
-        SafeGasPrice: lowGasPrice,
-        ProposeGasPrice: averageGasPrice,
-        FastGasPrice: fastGasPrice,
+        suggestBaseFee: String(suggestBaseFee),
+        SafeGasPrice: "100",
+        ProposeGasPrice: "110",
+        FastGasPrice: "120",
       },
     });
 
@@ -67,33 +63,29 @@ describe("getEthereumGasPrice", () => {
 
     expect(result).toEqual({
       low: {
-        maxPriorityFeePerGas: lowGasPrice,
-        maxFeePerGas: lowGasPrice,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
       },
       average: {
-        maxPriorityFeePerGas: averageGasPrice,
-        maxFeePerGas: averageGasPrice,
+        maxPriorityFeePerGas: 10,
+        maxFeePerGas: 110,
       },
       high: {
-        maxPriorityFeePerGas: fastGasPrice,
-        maxFeePerGas: fastGasPrice,
+        maxPriorityFeePerGas: 20,
+        maxFeePerGas: 120,
       },
-      asap: {
-        maxPriorityFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-        maxFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-      },
+      asap: getAsapGasPriceLevel(suggestBaseFee, 20),
     });
   });
   it("should return the Sepolia gas prices per level based on the Ethereum gas station", async () => {
-    const lowGasPrice = 100;
-    const averageGasPrice = 110;
-    const fastGasPrice = 120;
+    const suggestBaseFee = 100;
 
     const mock = mockFetch({
       result: {
-        SafeGasPrice: lowGasPrice,
-        ProposeGasPrice: averageGasPrice,
-        FastGasPrice: fastGasPrice,
+        suggestBaseFee: String(suggestBaseFee),
+        SafeGasPrice: "100",
+        ProposeGasPrice: "110",
+        FastGasPrice: "120",
       },
     });
 
@@ -104,33 +96,29 @@ describe("getEthereumGasPrice", () => {
 
     expect(result).toEqual({
       low: {
-        maxPriorityFeePerGas: lowGasPrice,
-        maxFeePerGas: lowGasPrice,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
       },
       average: {
-        maxPriorityFeePerGas: averageGasPrice,
-        maxFeePerGas: averageGasPrice,
+        maxPriorityFeePerGas: 10,
+        maxFeePerGas: 110,
       },
       high: {
-        maxPriorityFeePerGas: fastGasPrice,
-        maxFeePerGas: fastGasPrice,
+        maxPriorityFeePerGas: 20,
+        maxFeePerGas: 120,
       },
-      asap: {
-        maxPriorityFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-        maxFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-      },
+      asap: getAsapGasPriceLevel(suggestBaseFee, 20),
     });
   });
   it("should return the Rinkeby gas prices per level based on the Ethereum gas station", async () => {
-    const lowGasPrice = 100;
-    const averageGasPrice = 110;
-    const fastGasPrice = 120;
+    const suggestBaseFee = 100;
 
     const mock = mockFetch({
       result: {
-        SafeGasPrice: lowGasPrice,
-        ProposeGasPrice: averageGasPrice,
-        FastGasPrice: fastGasPrice,
+        suggestBaseFee: String(suggestBaseFee),
+        SafeGasPrice: "100",
+        ProposeGasPrice: "110",
+        FastGasPrice: "120",
       },
     });
 
@@ -141,21 +129,18 @@ describe("getEthereumGasPrice", () => {
 
     expect(result).toEqual({
       low: {
-        maxPriorityFeePerGas: lowGasPrice,
-        maxFeePerGas: lowGasPrice,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
       },
       average: {
-        maxPriorityFeePerGas: averageGasPrice,
-        maxFeePerGas: averageGasPrice,
+        maxPriorityFeePerGas: 10,
+        maxFeePerGas: 110,
       },
       high: {
-        maxPriorityFeePerGas: fastGasPrice,
-        maxFeePerGas: fastGasPrice,
+        maxPriorityFeePerGas: 20,
+        maxFeePerGas: 120,
       },
-      asap: {
-        maxPriorityFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-        maxFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-      },
+      asap: getAsapGasPriceLevel(suggestBaseFee, 20),
     });
   });
   it("should include the API key if provided for Ethereum", async () => {

--- a/lib/networks/__tests__/getPolygonGasPrice.test.ts
+++ b/lib/networks/__tests__/getPolygonGasPrice.test.ts
@@ -5,28 +5,28 @@ import { mockFetch } from "./mockFetch";
 import {
   GAS_STATION_URL_BY_NETWORK,
   DEFAULT_FALLBACK_GAS_PRICE,
-  ASAP_PERCENTAGE,
   getPolygonGasPrice,
 } from "../getPolygonGasPrice";
 
+import { getAsapGasPriceLevel } from "../../getAsapGasPriceLevel";
+
 describe("getPolygonGasPrice", () => {
   it("should return the Polygon gas prices per level based on the Polygon gas station", async () => {
-    const lowGasPrice = 100;
-    const averageGasPrice = 110;
-    const fastGasPrice = 120;
+    const estimatedBaseFee = 100;
 
     const mock = mockFetch({
+      estimatedBaseFee,
       safeLow: {
-        maxPriorityFee: lowGasPrice,
-        maxFee: lowGasPrice,
+        maxPriorityFee: 0,
+        maxFee: 100,
       },
       standard: {
-        maxPriorityFee: averageGasPrice,
-        maxFee: averageGasPrice,
+        maxPriorityFee: 1,
+        maxFee: 110,
       },
       fast: {
-        maxPriorityFee: fastGasPrice,
-        maxFee: fastGasPrice,
+        maxPriorityFee: 2,
+        maxFee: 120,
       },
     });
 
@@ -37,40 +37,36 @@ describe("getPolygonGasPrice", () => {
 
     expect(result).toEqual({
       low: {
-        maxPriorityFeePerGas: lowGasPrice,
-        maxFeePerGas: lowGasPrice,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
       },
       average: {
-        maxPriorityFeePerGas: averageGasPrice,
-        maxFeePerGas: averageGasPrice,
+        maxPriorityFeePerGas: 1,
+        maxFeePerGas: 110,
       },
       high: {
-        maxPriorityFeePerGas: fastGasPrice,
-        maxFeePerGas: fastGasPrice,
+        maxPriorityFeePerGas: 2,
+        maxFeePerGas: 120,
       },
-      asap: {
-        maxPriorityFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-        maxFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-      },
+      asap: getAsapGasPriceLevel(estimatedBaseFee, 2),
     });
   });
   it("should return the Mumbai gas prices per level based on the Polygon gas station", async () => {
-    const lowGasPrice = 100;
-    const averageGasPrice = 110;
-    const fastGasPrice = 120;
+    const estimatedBaseFee = 100;
 
     const mock = mockFetch({
+      estimatedBaseFee,
       safeLow: {
-        maxPriorityFee: lowGasPrice,
-        maxFee: lowGasPrice,
+        maxPriorityFee: 0,
+        maxFee: 100,
       },
       standard: {
-        maxPriorityFee: averageGasPrice,
-        maxFee: averageGasPrice,
+        maxPriorityFee: 1,
+        maxFee: 110,
       },
       fast: {
-        maxPriorityFee: fastGasPrice,
-        maxFee: fastGasPrice,
+        maxPriorityFee: 2,
+        maxFee: 120,
       },
     });
 
@@ -81,21 +77,18 @@ describe("getPolygonGasPrice", () => {
 
     expect(result).toEqual({
       low: {
-        maxPriorityFeePerGas: lowGasPrice,
-        maxFeePerGas: lowGasPrice,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
       },
       average: {
-        maxPriorityFeePerGas: averageGasPrice,
-        maxFeePerGas: averageGasPrice,
+        maxPriorityFeePerGas: 1,
+        maxFeePerGas: 110,
       },
       high: {
-        maxPriorityFeePerGas: fastGasPrice,
-        maxFeePerGas: fastGasPrice,
+        maxPriorityFeePerGas: 2,
+        maxFeePerGas: 120,
       },
-      asap: {
-        maxPriorityFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-        maxFeePerGas: (fastGasPrice * ASAP_PERCENTAGE) / 100,
-      },
+      asap: getAsapGasPriceLevel(estimatedBaseFee, 2),
     });
   });
   it("should return the fallback gas price if there an issue fetching from the Polygon gas station", async () => {


### PR DESCRIPTION
Tumbled upon https://www.blocknative.com/blog/eip-1559-fees and I took the chance to significantly improve the `asap` gas price level algorithm.

Also noticed the Ethereum gas station prices are being returned via strings (quite sure it was not the case before). Fixed it.