### PR TITLE
feat: move isomorphic-unfetch to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Gas price is constantly changing on every blockchain network based on demand to 
 
 ## Getting started
 
-1. Install the package
+1. Install the package & its peer dependency
 
 ```sh
-yarn add @enzoferey/network-gas-price
+yarn add @enzoferey/network-gas-price isomorphic-unfetch
 ```
 
 2. Get network prices

--- a/package.json
+++ b/package.json
@@ -37,19 +37,20 @@
     "test": "vitest",
     "test:ci": "vitest --coverage --run"
   },
+  "peerDependencies": {
+    "isomorphic-unfetch": ">=4.0.2"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "c8": "^7.12.0",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
+    "isomorphic-unfetch": "^4.0.2",
     "prettier": "2.7.1",
     "typescript": "^4.7.4",
     "vite": "^3.0.2",
     "vite-plugin-dts": "^1.4.0",
     "vitest": "^0.18.1"
-  },
-  "dependencies": {
-    "isomorphic-unfetch": "^4.0.2"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,26 +4,19 @@ import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
 export default defineConfig({
-  // Required until https://github.com/developit/unfetch/pull/164 is merged
-  resolve: {
-    alias: [
-      {
-        find: "unfetch",
-        replacement: path.resolve(
-          __dirname,
-          "node_modules",
-          "unfetch",
-          "dist",
-          "unfetch.mjs"
-        ),
-      },
-    ],
-  },
   build: {
     lib: {
       entry: path.resolve(__dirname, "lib/index.ts"),
       name: "network-gas-price",
       fileName: "network-gas-price",
+    },
+    rollupOptions: {
+      external: ["isomorphic-unfetch"],
+      output: {
+        globals: {
+          "isomorphic-unfetch": "fetch",
+        },
+      },
     },
   },
   plugins: [dts()],


### PR DESCRIPTION
Follow up on https://github.com/enzoferey/network-gas-price/pull/13.

`unfetch` package has several building issues at the moment (read [this](https://github.com/developit/unfetch/issues/150)) and it makes it hard to bundle within the library as of right now. I think the ideal solution will be passing in a `fetch`-like function into the library so the user can choose what to use. A future iteration maybe.