### PR TITLE
fix: parse random string values from the Polygon gas station

### DIFF
--- a/lib/networks/__tests__/getPolygonGasPrice.test.ts
+++ b/lib/networks/__tests__/getPolygonGasPrice.test.ts
@@ -91,6 +91,46 @@ describe("getPolygonGasPrice", () => {
       asap: getAsapGasPriceLevel(estimatedBaseFee, 2),
     });
   });
+  it("should parse string prices randomly returned", async () => {
+    const estimatedBaseFee = "100";
+
+    const mock = mockFetch({
+      estimatedBaseFee,
+      safeLow: {
+        maxPriorityFee: "0",
+        maxFee: "100",
+      },
+      standard: {
+        maxPriorityFee: "1",
+        maxFee: "110",
+      },
+      fast: {
+        maxPriorityFee: "2",
+        maxFee: "120",
+      },
+    });
+
+    const result = await getPolygonGasPrice("polygon");
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith(GAS_STATION_URL_BY_NETWORK.polygon);
+
+    expect(result).toEqual({
+      low: {
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 100,
+      },
+      average: {
+        maxPriorityFeePerGas: 1,
+        maxFeePerGas: 110,
+      },
+      high: {
+        maxPriorityFeePerGas: 2,
+        maxFeePerGas: 120,
+      },
+      asap: getAsapGasPriceLevel(parseFloat(estimatedBaseFee), 2),
+    });
+  });
   it("should return the fallback gas price if there an issue fetching from the Polygon gas station", async () => {
     mockFetch(undefined, { ok: false });
 

--- a/lib/networks/getPolygonGasPrice.ts
+++ b/lib/networks/getPolygonGasPrice.ts
@@ -39,28 +39,28 @@ export async function getPolygonGasPrice(
   try {
     const gasStationUrl = GAS_STATION_URL_BY_NETWORK[network];
 
-    const responsePolygonGasPrice = await fetch(
-      gasStationUrl
-    ).then<ResponsePolygonGasPrice>(async (response) => {
-      const jsonResponse = await response.json();
-
-      // Polygon gas station types are not consistent
-      return {
-        estimatedBaseFee: parseFloat(jsonResponse.estimatedBaseFee),
-        safeLow: {
-          maxPriorityFee: parseFloat(jsonResponse.safeLow.maxPriorityFee),
-          maxFee: parseFloat(jsonResponse.safeLow.maxFee),
-        },
-        standard: {
-          maxPriorityFee: parseFloat(jsonResponse.standard.maxPriorityFee),
-          maxFee: parseFloat(jsonResponse.standard.maxFee),
-        },
-        fast: {
-          maxPriorityFee: parseFloat(jsonResponse.fast.maxPriorityFee),
-          maxFee: parseFloat(jsonResponse.fast.maxFee),
-        },
-      };
-    });
+    const responsePolygonGasPrice = await fetch(gasStationUrl)
+      .then(async (response) => {
+        return response.json();
+      })
+      .then<ResponsePolygonGasPrice>((response) => {
+        // Polygon gas station types are not consistent
+        return {
+          estimatedBaseFee: parseFloat(response.estimatedBaseFee),
+          safeLow: {
+            maxPriorityFee: parseFloat(response.safeLow.maxPriorityFee),
+            maxFee: parseFloat(response.safeLow.maxFee),
+          },
+          standard: {
+            maxPriorityFee: parseFloat(response.standard.maxPriorityFee),
+            maxFee: parseFloat(response.standard.maxFee),
+          },
+          fast: {
+            maxPriorityFee: parseFloat(response.fast.maxPriorityFee),
+            maxFee: parseFloat(response.fast.maxFee),
+          },
+        };
+      });
 
     const asapGasPriceLevel = getAsapGasPriceLevel(
       responsePolygonGasPrice.estimatedBaseFee,

--- a/lib/networks/getPolygonGasPrice.ts
+++ b/lib/networks/getPolygonGasPrice.ts
@@ -41,8 +41,25 @@ export async function getPolygonGasPrice(
 
     const responsePolygonGasPrice = await fetch(
       gasStationUrl
-    ).then<ResponsePolygonGasPrice>((response) => {
-      return response.json();
+    ).then<ResponsePolygonGasPrice>(async (response) => {
+      const jsonResponse = await response.json();
+
+      // Polygon gas station types are not consistent
+      return {
+        estimatedBaseFee: parseFloat(jsonResponse.estimatedBaseFee),
+        safeLow: {
+          maxPriorityFee: parseFloat(jsonResponse.safeLow.maxPriorityFee),
+          maxFee: parseFloat(jsonResponse.safeLow.maxFee),
+        },
+        standard: {
+          maxPriorityFee: parseFloat(jsonResponse.standard.maxPriorityFee),
+          maxFee: parseFloat(jsonResponse.standard.maxFee),
+        },
+        fast: {
+          maxPriorityFee: parseFloat(jsonResponse.fast.maxPriorityFee),
+          maxFee: parseFloat(jsonResponse.fast.maxFee),
+        },
+      };
     });
 
     const asapGasPriceLevel = getAsapGasPriceLevel(


### PR DESCRIPTION
Follow up on https://github.com/enzoferey/network-gas-price/pull/26.

The Polygon gas station sometimes randomly returns string values instead of number ones.